### PR TITLE
Add --exec-post-freeze argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,13 @@ this hierarchy will be the ``lodge`` directory.
 Now you can freeze your project into a git-free, commitable and deployable tree of source code.
 This will go into the ``dam`` directory.
 
+If you want to execute post freeze commands on apply add the ``--exec-post-freeze``
+argument like so :
+
+.. code-block::
+
+    castor apply --exec-post-freeze
+
 .. code-block::
 
    castor freeze

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,13 @@ Your ``Castorfile`` being filled up, you can now apply it
 This will automatically create your repositories hierarchy, checkout submodules, etc. The root of
 this hierarchy will be the ``lodge`` directory.
 
+If you want to execute post freeze commands on apply add the ``--exec-post-freeze``
+argument like so :
+
+.. code-block::
+
+    castor apply --exec-post-freeze
+
 Now you can freeze your project into a git-free, commitable and deployable tree of source code.
 This will go into the ``dam`` directory.
 

--- a/bin/castor
+++ b/bin/castor
@@ -21,7 +21,14 @@ def parse_cli():
                                                                             'initialize (defaults '
                                                                             'to current directory)')
 
-    s.add_parser('apply', help='Apply the Castorfile')
+    a_apply = s.add_parser('apply', help='Apply the Castorfile')
+    a_apply.add_argument(
+        '--exec-post-freeze',
+        action='store_true',
+        default=False,
+        help='Execute post freeze on apply'
+    )
+
     s.add_parser('freeze', help='Report current Git commits to Castorfile, assemble all files in '
                                 'the dam directory and add them to the Git index.')
 
@@ -47,8 +54,8 @@ def do_init(directory):
     init(directory)
 
 
-def do_apply():
-    make_castor().apply()
+def do_apply(exec_post_freeze):
+    make_castor().apply(exec_post_freeze)
 
 
 def do_freeze():

--- a/tests/repo.py
+++ b/tests/repo.py
@@ -164,6 +164,17 @@ class TestCastor(unittest.TestCase):
         self.assertEqual(str(repo.head.commit), 'cb83f96c803fb1067d7932a808b6f6eddf096ae5')
         self.assertFalse(repo.is_dirty())
         self.assertEqual(repo.untracked_files, [])
+        self.assertFalse(path.exists(path.join(self.test_root, 'lodge', 'modules', 'test', 'foo')))
+
+    def test_apply_exec_post_freeze(self):
+        c = Castor(self.test_root)
+        c.apply(True)
+
+        repo = git.Repo(path.join(self.test_root, 'lodge'))
+        self.assertEqual(str(repo.head.commit), 'cb83f96c803fb1067d7932a808b6f6eddf096ae5')
+        self.assertFalse(repo.is_dirty())
+        self.assertEqual(repo.untracked_files, [])
+        self.assertTrue(path.exists(path.join(self.test_root, 'lodge', 'modules', 'test', 'foo')))
 
     def test_write_castorfile(self):
         c = Castor(self.test_root)


### PR DESCRIPTION
This changes allow us to execute post freeze commands on applying the castor project.

``` console
$ castor apply --exec-post-freeze
```
